### PR TITLE
Avoid using edit URL when sharing

### DIFF
--- a/minishare.php
+++ b/minishare.php
@@ -66,7 +66,12 @@ class YellowMinishare {
             }
             $twitteruser = $this->yellow->system->get("minishareTwitterUser");
             $values = [
-                "{url}"=>rawurlencode($this->yellow->page->getUrl()),
+                "{url}"=>rawurlencode($this->yellow->lookup->normaliseUrl(
+                    $this->yellow->system->get("coreServerScheme"),
+                    $this->yellow->system->get("coreServerAddress"),
+                    $this->yellow->system->get("coreServerBase"),
+                    $page->location
+                )),
                 "{title}"=>rawurlencode($this->yellow->page->get("title")),
                 "{via}"=>$twitteruser ? "&via=".substr($twitteruser, 1) : "", // no initial @
             ];


### PR DESCRIPTION
This should fix accidental sharing of page URLs with edit handler. Nearly happened to me a few times when posting my own articles to WhatsApp and other services. Hope this can be useful. 🙂