### PR TITLE
Fix minishare.ini installation setting

### DIFF
--- a/extension.ini
+++ b/extension.ini
@@ -14,4 +14,4 @@ system/workers/minishare.js: minishare.js, create, update
 system/workers/minishare-plain.css: minishare-plain.css, create, update
 system/workers/minishare-squared.css: minishare-squared.css, create, update
 system/workers/minishare-rounded.css: minishare-rounded.css, create, update
-system/extensions/minishare.csv: minishare.csv, create, update, careful
+system/extensions/minishare.ini: minishare.ini, create, update, careful


### PR DESCRIPTION
Changed `minishare.csv` reference to `minishare.ini` in installation settings. 